### PR TITLE
Replace postgres: by postgresql: for database_url

### DIFF
--- a/layout_client/register_layout_detectors.py
+++ b/layout_client/register_layout_detectors.py
@@ -26,7 +26,7 @@ layout_engines = [
 def main():
     args = parseargs()
 
-    database_url = 'postgres://postgres:pero@localhost:5432/' + args.database
+    database_url = 'postgresql://postgres:pero@localhost:5432/' + args.database
     engine = create_engine(database_url, convert_unicode=True)
     db_session = scoped_session(sessionmaker(autocommit=False,
                                              autoflush=False,

--- a/ocr_client/register_baseline.py
+++ b/ocr_client/register_baseline.py
@@ -23,7 +23,7 @@ baseline_engines = [
 def main():
     args = parseargs()
 
-    database_url = 'postgres://postgres:pero@localhost:5432/' + args.database
+    database_url = 'postgresql://postgres:pero@localhost:5432/' + args.database
     engine = create_engine(database_url, convert_unicode=True)
     db_session = scoped_session(sessionmaker(autocommit=False,
                                              autoflush=False,

--- a/utils/change_image_path_to_basename.py
+++ b/utils/change_image_path_to_basename.py
@@ -16,7 +16,7 @@ def parseargs():
 def main():
     args = parseargs()
 
-    database_url = 'postgres://postgres:pero@localhost:5432/' + args.database
+    database_url = 'postgresql://postgres:pero@localhost:5432/' + args.database
     engine = create_engine(database_url, convert_unicode=True)
     db_session = scoped_session(sessionmaker(autocommit=False, autoflush=False, bind=engine))
 

--- a/utils/change_password.py
+++ b/utils/change_password.py
@@ -18,7 +18,7 @@ def parseargs():
 def main():
     args = parseargs()
 
-    database_url = 'postgres://postgres:pero@localhost:5432/' + args.database
+    database_url = 'postgresql://postgres:pero@localhost:5432/' + args.database
     engine = create_engine(database_url, convert_unicode=True)
     db_session = scoped_session(sessionmaker(autocommit=False, autoflush=False, bind=engine))
 

--- a/utils/check_expired_requests.py
+++ b/utils/check_expired_requests.py
@@ -24,7 +24,7 @@ def parseargs():
 def main():
     args = parseargs()
 
-    database_url = 'postgres://{}:{}@localhost:5432/{}'.format(args.user, args.password, args.database)
+    database_url = 'postgresql://{}:{}@localhost:5432/{}'.format(args.user, args.password, args.database)
     engine = create_engine(database_url, convert_unicode=True)
     db_session = scoped_session(sessionmaker(autocommit=False, autoflush=False, bind=engine))
 

--- a/utils/upload_document.py
+++ b/utils/upload_document.py
@@ -27,7 +27,7 @@ def parseargs():
 def main():
     args = parseargs()
 
-    database_url = 'postgres://postgres:pero@localhost:5432/' + args.database
+    database_url = 'postgresql://postgres:pero@localhost:5432/' + args.database
     engine = create_engine(database_url, convert_unicode=True)
     db_session = scoped_session(sessionmaker(autocommit=False,
                                              autoflush=False,


### PR DESCRIPTION
The latest versions of SQLAlchemy no longer support "postgres:".
That old URL form was deprecated more than 10 years ago:

https://github.com/sqlalchemy/sqlalchemy/blob/8fc5005dfe3eb66a46470ad8a8c7b95fc4d6bdca/lib/sqlalchemy/dialects/postgres.py

Signed-off-by: Stefan Weil <sw@weilnetz.de>