### PR TITLE
Fix size of database column 'password'

### DIFF
--- a/app/db/user.py
+++ b/app/db/user.py
@@ -9,7 +9,7 @@ class User(UserMixin, Base):
     __tablename__ = 'users'
     id = Column(Integer, primary_key=True)
     email = Column(String(100), unique=True)
-    password = Column(String(100))
+    password = Column(String(102))
     first_name = Column(String(100))
     last_name = Column(String(100))
     institution = Column(String(300))


### PR DESCRIPTION
A value looks like this:

pbkdf2:sha256:260000$jJTbsXK42NKdjoYi$28d34c35bf51f74a2e47023e0d06312fbb84ff7f63fdb3df3c7a9b29f2195b75

That's 6 + 1 + 6 + 1 + 88 = 102 characters.

Signed-off-by: Stefan Weil <sw@weilnetz.de>